### PR TITLE
feat: allow focus() on auro- and ods-button #72

### DIFF
--- a/src/auro-component-base.js
+++ b/src/auro-component-base.js
@@ -32,6 +32,9 @@ export default class AuroComponentBase extends LitElement {
     };
   }
 
+  focus() {
+    this.renderRoot.querySelector('button').focus();
+  }
 
   getIcon(svgIcon) {
     this.dom = new DOMParser().parseFromString(svgIcon, 'text/html');
@@ -53,7 +56,7 @@ export default class AuroComponentBase extends LitElement {
       'auro-button--secondary': this.secondary,
       'auro-buttonOndark--secondary': this.secondary && this.ondark,
       'auro-button--tertiary': this.tertiary,
-      'auro-buttonOndark--tertiary': this.tertiary && this.ondark,
+      'auro-buttonOndark--tertiary': this.tertiary && this.ondark
     };
 
     return html`

--- a/src/component-base.js
+++ b/src/component-base.js
@@ -53,6 +53,10 @@ export default class ComponentBase extends LitElement {
     };
   }
 
+  focus() {
+    this.renderRoot.querySelector('button').focus();
+  }
+
   getButtontype(type) {
     return type === "secondary" ? "ods-button--secondary" : ""
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #72 

## Summary:

This adds a focus method to ods-button, auro-button, and their associated light DOM versions.

Note that the focus state will only be visible if the user is currently navigating with a keyboard (e.g. triggering the close button of a modal with the keyboard and returning focus to the button that triggered the modal).

[Related PR in ods-inputtext](https://github.com/AlaskaAirlines/ods-inputtext/pull/16).

## Type of change:

- [x] New capability 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
