### PR TITLE
style: remove firefox-only focus outline #76

### DIFF
--- a/src/style-auro.scss
+++ b/src/style-auro.scss
@@ -105,6 +105,10 @@ slot {
     }
   }
 
+  // remove Firefox-only focus outline
+  &::-moz-focus-inner {
+    border: none;
+  }
 
   // handle active state
   &:active {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #76

## Summary:

This removes the Firefox-only focus outline from auro-button.

![image](https://user-images.githubusercontent.com/4992896/85081074-d0302300-b17f-11ea-859b-9ecc43fa46b1.png)


## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
